### PR TITLE
docs: add usage guide, architecture overview, and CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ Every message is cryptographically signed — tampered messages are rejected by 
 - Join requests queue up for private communities — owners navigate and act on each
 - No moderation from above — communities self-govern
 
+## Documentation
+
+The README provides a high-level overview of Y. For more detailed guides and reference material, see the documentation below.
+
+| Document                             | Description                                                                                                                                                         |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Usage Guide](docs/usage.md)         | Step-by-step walkthrough for getting started with Y, creating your identity, navigating the interface, messaging, communities, and bookmarks.                       |
+| [Architecture](docs/architecture.md) | Overview of Y's internal architecture, including identity management, networking, Tor integration, gossip propagation, distributed storage, and application design. |
+| [CLI Reference](docs/cli.md)         | Complete reference for command-line subcommands, interactive commands, keyboard shortcuts, and supported environment variables.                                     |
+
+
 ## Install & Run
 
 ### One-liner (Linux / macOS)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ On first run, Y bootstraps the Tor client and creates your hidden service. This 
 
 Y ships with a default seed node called **the mediator**. On startup, your client connects to it automatically and discovers other peers through the DHT. No manual peer configuration needed.
 
-The mediator has no special privileges — it's just a peer that's always online. It can't read your DMs, censor posts, or control the network. Every peer relays messages the same way; the mediator is simply the one you can always reach. If it goes down, existing peers continue talking to each other.
+The mediator has no special privileges — it's just a peer that's always online. It also temporarily stores encrypted direct messages for offline users until they reconnect. It cannot read message contents, censor posts, or control the network.
 
 You can override or add additional seed nodes:
 
@@ -178,7 +178,7 @@ This removes the binary and all local data (`~/.root-chat`).
 | `x` | Delete your post |
 | `g` | Go to post (from bookmarks) |
 | `a` | Approve pending request (community detail) |
-| `x` | Decline pending request (community detail) |
+| `x` | Decline selected join request (community detail) |
 | `Enter` | Expand/collapse replies, open community |
 | `Shift+Enter` | New line while composing |
 | `/` | Search users |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,11 @@ The application is organized into modular components responsible for cryptograph
 
 Every user owns a cryptographic identity that is generated locally during the first launch.
 
-The identity is based on an Ed25519 keypair used to sign messages and derive the user's permanent address. Since identities are never managed by a central authority, users remain in full control of their credentials and can authenticate messages without relying on external services.
+Y uses an Ed25519 keypair for identity and digital signatures, allowing peers to verify the authenticity of messages without relying on a central authority.
+
+For end-to-end encrypted direct messages, Y derives X25519 keys from the identity to perform an Elliptic-Curve Diffie-Hellman (ECDH) key exchange. The shared secret is then used with ChaCha20Poly1305 to encrypt message contents.
+
+Since identities are generated and stored locally, users remain in full control of their credentials.
 
 ---
 
@@ -54,6 +58,8 @@ The identity is based on an Ed25519 keypair used to sign messages and derive the
 Y communicates exclusively over Tor hidden services. Each node exposes a `.onion` address, allowing peers to establish connections without revealing their public IP addresses.
 
 The networking layer is managed by the `NetworkEngine`, which is responsible for peer connections, message propagation, peer discovery, direct message routing, and coordination with the distributed storage layer.
+
+Some peers can also operate as mediator (seed) nodes. In addition to helping new peers discover the network, mediator nodes temporarily relay public messages and store encrypted direct messages for offline users until they reconnect. They do not control the network or gain access to message contents.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,129 @@
+# Architecture
+
+## Overview
+
+Y is built around a decentralized, peer-to-peer architecture where every instance acts as both a client and a network participant. Instead of relying on centralized infrastructure, each node maintains its own identity, communicates directly with peers over the Tor network, stores local data, and participates in message propagation and distributed storage.
+
+The application is organized into modular components responsible for cryptography, networking, storage, communities, and the terminal user interface.
+
+---
+
+## High-Level Architecture
+
+```text
+                 +----------------------+
+                 |     Terminal UI      |
+                 +----------+-----------+
+                            |
+                            v
+                 +----------------------+
+                 |    Network Engine    |
+                 +----------+-----------+
+                            |
+        +-------------------+-------------------+
+        |                   |                   |
+        v                   v                   v
++---------------+   +----------------+   +---------------+
+|    Crypto     |   |    Protocol    |   |    Storage    |
++---------------+   +----------------+   +---------------+
+        |                   |                   |
+        |                   |                   |
+        |            +------+-------+           |
+        |            |              |           |
+        |            v              v           |
+        |        Tor Transport   Kademlia DHT  |
+        |            |              |           |
+        +------------+------+-------+-----------+
+                             |
+                             v
+                        Other Y Peers
+```
+
+---
+
+## Identity
+
+Every user owns a cryptographic identity that is generated locally during the first launch.
+
+The identity is based on an Ed25519 keypair used to sign messages and derive the user's permanent address. Since identities are never managed by a central authority, users remain in full control of their credentials and can authenticate messages without relying on external services.
+
+---
+
+## Networking
+
+Y communicates exclusively over Tor hidden services. Each node exposes a `.onion` address, allowing peers to establish connections without revealing their public IP addresses.
+
+The networking layer is managed by the `NetworkEngine`, which is responsible for peer connections, message propagation, peer discovery, direct message routing, and coordination with the distributed storage layer.
+
+---
+
+## Wire Protocol
+
+Communication between peers is performed through serialized `WireMessage` packets.
+
+The protocol includes message types for:
+
+* Peer handshake (`Hello`, `HelloAck`)
+* Public timeline synchronization
+* Gossip propagation of posts
+* End-to-end encrypted direct messages
+* Peer discovery
+* DHT requests and responses
+* Keep-alive (`Ping` / `Pong`)
+* Notification events such as nod propagation
+
+This message-oriented design keeps communication structured while allowing new protocol features to be added without changing the transport layer.
+
+---
+
+## Gossip Protocol
+
+Public posts are propagated using a gossip-based protocol.
+
+Instead of forwarding every message through a central relay, peers exchange newly received posts with connected neighbors. Each receiving peer verifies the message before propagating it further, allowing content to spread throughout the network while avoiding single points of failure.
+
+---
+
+## Distributed Storage
+
+Y uses a Kademlia-based Distributed Hash Table (DHT) to distribute and replicate data across participating nodes.
+
+The DHT is responsible for storing and retrieving shared network data, allowing content such as posts and encrypted direct messages to remain available even when the original sender is temporarily offline.
+
+---
+
+## Local Storage
+
+Local persistence is provided by the embedded `sled` database.
+
+Each node stores its own application data locally, including information such as:
+
+* Cryptographic identity
+* User alias
+* Cached messages
+* Bookmarks
+* Timeline data
+
+Because storage is fully embedded, Y does not require an external database server.
+
+---
+
+## Terminal User Interface
+
+Y provides a terminal-based user interface (TUI) built around an event-driven architecture.
+
+The interface handles user interaction, rendering, keyboard shortcuts, and navigation while the networking components continue processing peer communication in the background. This separation keeps the interface responsive during synchronization and message exchange.
+
+---
+
+## Design Goals
+
+The architecture is designed around several core principles:
+
+* Decentralization without centralized infrastructure.
+* Cryptographic identity instead of account-based authentication.
+* Privacy through Tor hidden services.
+* Distributed message propagation using gossip.
+* Resilient storage through a Kademlia DHT.
+* Local ownership of user data.
+* Modular components with clearly separated responsibilities.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -53,12 +53,36 @@ y serve
 
 ## `y update`
 
-Checks GitHub for the latest release and updates the installed binary when a newer version is available.
+Checks for the latest available release and updates the installed binary if a newer version is available.
 
 Example:
 
 ```bash
 y update
+```
+
+---
+
+## `y reset`
+
+Removes local application data including:
+
+- Timeline
+- Bookmarks
+- Cache
+
+Your identity is preserved. Use `--new-identity` to generate a new one.
+
+Example:
+
+```bash
+y reset
+```
+
+To generate a completely new identity as well:
+
+```bash
+y reset --new-identity
 ```
 
 ---
@@ -81,17 +105,18 @@ Inside the application, press `:` to enter command mode.
 
 Available commands include:
 
-| Command                  | Description                        |
-| ------------------------ | ---------------------------------- |
-| `:whoami`                | Display your identity and handle   |
-| `:peers`                 | Show the number of connected peers |
-| `:alias <name>`          | Set a custom alias                 |
-| `:alias-gen`             | Generate a random alias            |
-| `:search <query>`        | Search users                       |
-| `:create <name>`         | Create a public community          |
-| `:create <name> private` | Create a private community         |
-| `:join <id>`             | Join a community                   |
-| `:quit`                  | Exit the application               |
+| Command | Description |
+|---------|-------------|
+| `:whoami` | Display your identity and handle |
+| `:peers` | Show the number of connected peers |
+| `:alias <name>` | Set a custom alias |
+| `:alias-gen` | Generate a random alias |
+| `:search <query>` | Search users |
+| `:create <name>` | Create a public community |
+| `:create <name> private` | Create a private community |
+| `:join <id>` | Join a community |
+| `:q` | Exit the application |
+| `:quit` | Exit the application |
 
 ---
 
@@ -120,14 +145,23 @@ The terminal interface is keyboard-driven.
 
 Some commonly used shortcuts include:
 
-| Key | Action          |
-| --- | --------------- |
-| `t` | Timeline        |
+| Key | Action |
+| --- | ------ |
+| `t` | Timeline |
 | `d` | Direct messages |
-| `c` | Communities     |
-| `b` | Bookmarks       |
-| `p` | Profile         |
-| `n` | New post        |
-| `q` | Quit            |
+| `c` | Communities |
+| `b` | Bookmarks |
+| `p` | Profile |
+| `n` | Compose a new post |
+| `.` | Nod / Like the selected post |
+| `s` | Bookmark the selected post |
+| `r` | Reply to the selected post |
+| `x` | Delete your own selected post |
+| `/` | Search for users |
+| `i` | Start typing in the selected DM conversation |
+| `j` | Move to the next item |
+| `k` | Move to the previous item |
+| `g` | Open the original post from Bookmarks |
+| `Enter` | Open the selected item or expand/collapse a thread |
 
-Refer to the main README for the complete list of available shortcuts.
+

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,133 @@
+# CLI Reference
+
+## Overview
+
+Y provides a small set of command-line subcommands for launching the application, running infrastructure nodes, updating the installation, and removing local data.
+
+If no subcommand is provided, running `y` starts the chat interface.
+
+---
+
+# Commands
+
+## `y`
+
+Starts the interactive terminal interface.
+
+Equivalent to:
+
+```bash
+y open
+```
+
+---
+
+## `y open`
+
+Launches the terminal user interface.
+
+During startup Y:
+
+* Loads or creates your identity.
+* Opens the local database.
+* Starts the Tor client.
+* Creates a hidden service.
+* Connects to configured peers.
+* Opens the chat interface.
+
+---
+
+## `y serve`
+
+Runs Y without the terminal interface.
+
+This mode is intended for always-on machines acting as seed nodes for peer discovery.
+
+Example:
+
+```bash
+y serve
+```
+
+---
+
+## `y update`
+
+Checks GitHub for the latest release and updates the installed binary when a newer version is available.
+
+Example:
+
+```bash
+y update
+```
+
+---
+
+## `y uninstall`
+
+Removes the installed binary together with local application data.
+
+Example:
+
+```bash
+y uninstall
+```
+
+---
+
+# Command Mode
+
+Inside the application, press `:` to enter command mode.
+
+Available commands include:
+
+| Command                  | Description                        |
+| ------------------------ | ---------------------------------- |
+| `:whoami`                | Display your identity and handle   |
+| `:peers`                 | Show the number of connected peers |
+| `:alias <name>`          | Set a custom alias                 |
+| `:alias-gen`             | Generate a random alias            |
+| `:search <query>`        | Search users                       |
+| `:create <name>`         | Create a public community          |
+| `:create <name> private` | Create a private community         |
+| `:join <id>`             | Join a community                   |
+| `:quit`                  | Exit the application               |
+
+---
+
+# Environment Variables
+
+Y supports several optional environment variables for configuring startup behavior.
+
+| Variable     | Description                               |
+| ------------ | ----------------------------------------- |
+| `Y_DATA_DIR` | Override the default local data directory |
+| `Y_SEEDS`    | Specify one or more seed nodes            |
+| `Y_PEER`     | Connect directly to a specific peer       |
+| `Y_PORT`     | Change the listening port                 |
+
+Example:
+
+```bash
+Y_PORT=8080 Y_DATA_DIR=~/.root-chat-dev y open
+```
+
+---
+
+# Keyboard Shortcuts
+
+The terminal interface is keyboard-driven.
+
+Some commonly used shortcuts include:
+
+| Key | Action          |
+| --- | --------------- |
+| `t` | Timeline        |
+| `d` | Direct messages |
+| `c` | Communities     |
+| `b` | Bookmarks       |
+| `p` | Profile         |
+| `n` | New post        |
+| `q` | Quit            |
+
+Refer to the main README for the complete list of available shortcuts.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,159 @@
+# Usage Guide
+
+## Overview
+
+Y is a decentralized chat platform that operates without centralized servers or user accounts. Instead of creating an account with an email address or phone number, your identity is created from a cryptographic keypair generated on your device.
+
+Communication takes place over the Tor network, helping keep your network location private while allowing peers to communicate directly. Public posts, encrypted direct messages, and communities are all built on the same decentralized network.
+
+This guide walks through the most common tasks you'll perform when using Y.
+
+---
+
+## First Launch
+
+Start Y by running:
+
+```bash
+y open
+```
+
+On the first launch, Y performs several setup steps automatically:
+
+* Generates your cryptographic identity.
+* Creates a local data directory.
+* Boots the embedded Tor client.
+* Starts your hidden service.
+* Connects to available peers through the configured seed nodes.
+
+The first startup may take longer than later launches because Tor needs to download its initial network information.
+
+Once initialization is complete, the terminal interface opens and you're ready to interact with the network.
+
+---
+
+## Your Identity
+
+Every installation has its own identity consisting of three parts:
+
+### Address
+
+Your permanent cryptographic identifier, derived from your public key.
+
+Example:
+
+```
+root:a8Kx2m...
+```
+
+This address uniquely identifies you across the network.
+
+### Alias
+
+A human-friendly display name.
+
+Aliases can be changed at any time and are **not unique**.
+
+### Handle
+
+The handle combines your alias with a shortened version of your address.
+
+Example:
+
+```
+phantom-cipher#a8Kx
+```
+
+This makes it easier to distinguish users with the same alias.
+
+Never share your private keys with anyone. Your identity belongs entirely to you.
+
+---
+
+## Navigating the Interface
+
+The terminal interface is divided into multiple sections that let you browse different parts of the network.
+
+Common views include:
+
+* Timeline
+* Direct Messages
+* Communities
+* Bookmarks
+* Profile
+
+Navigate using the documented keyboard shortcuts and switch between views without leaving the application.
+
+---
+
+## Creating Your First Post
+
+To publish a public message:
+
+1. Open the Timeline.
+2. Press the compose shortcut.
+3. Write your message.
+4. Submit it.
+
+Every public post is digitally signed before being broadcast through the network. Other peers verify the signature before accepting the message.
+
+---
+
+## Sending Direct Messages
+
+Direct messages are encrypted before leaving your device.
+
+Only the intended recipient can decrypt the message contents.
+
+If the recipient is temporarily offline, encrypted messages remain available through the distributed network until they are retrieved.
+
+---
+
+## Communities
+
+Communities allow discussions around shared interests.
+
+Y supports two community types:
+
+* Open communities that anyone can join.
+* Private communities that require approval from the owner.
+
+Community owners manage membership requests directly without relying on centralized moderation.
+
+---
+
+## Searching for Users
+
+Open command mode and use the search command to locate users by alias or address.
+
+If multiple users share the same alias, compare their handles to identify the correct person.
+
+---
+
+## Bookmarks
+
+Bookmarks let you save interesting posts locally for future reference.
+
+Bookmarks exist only on your device and are not shared with other peers.
+
+---
+
+## Running a Seed Node
+
+If you operate an always-on machine such as a VPS or Raspberry Pi, you can run Y in headless mode:
+
+```bash
+y serve
+```
+
+Seed nodes help new peers discover the network and improve overall resilience. They do not receive special privileges or control the network.
+
+---
+
+## Tips
+
+* Keep your private keys secure.
+* Use aliases to make conversations easier to follow.
+* Leave a seed node running if you have a reliable server.
+* Keep Y updated to receive protocol improvements and bug fixes.
+* Review the CLI reference for additional commands and configuration options.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,11 +101,18 @@ Every public post is digitally signed before being broadcast through the network
 
 ## Sending Direct Messages
 
-Direct messages are encrypted before leaving your device.
+To start a direct message:
 
-Only the intended recipient can decrypt the message contents.
+1. Press `/` to search for a user.
+2. Select the desired peer from the search results.
+3. Press `Enter` to open the conversation.
+4. Press `i` to start typing.
+5. Type your message.
+6. Press `Enter` to send it.
 
-If the recipient is temporarily offline, encrypted messages remain available through the distributed network until they are retrieved.
+All direct messages are end-to-end encrypted.
+
+If the recipient is temporarily offline, encrypted messages remain available through the network until they are delivered.
 
 ---
 
@@ -124,7 +131,7 @@ Community owners manage membership requests directly without relying on centrali
 
 ## Searching for Users
 
-Open command mode and use the search command to locate users by alias or address.
+Press `/` to search for users by alias or address.
 
 If multiple users share the same alias, compare their handles to identify the correct person.
 
@@ -155,5 +162,5 @@ Seed nodes help new peers discover the network and improve overall resilience. T
 * Keep your private keys secure.
 * Use aliases to make conversations easier to follow.
 * Leave a seed node running if you have a reliable server.
-* Keep Y updated to receive protocol improvements and bug fixes.
+* Run `y update` regularly to install the latest release.
 * Review the CLI reference for additional commands and configuration options.


### PR DESCRIPTION
## Summary

This PR expands the project's documentation by introducing dedicated guides under the new `docs/` directory while keeping the README concise as the primary entry point.

### Changes

- Added a comprehensive Usage Guide for new users.
- Added an Architecture Overview describing Y's major components and networking model.
- Added a CLI Reference covering subcommands, keyboard shortcuts, and environment variables.
- Updated the README with a Documentation section linking to the new guides.

These changes improve onboarding for users and contributors while preserving the README as a concise entry point.